### PR TITLE
Username route test fixes

### DIFF
--- a/packages/backend/test/environment.ts
+++ b/packages/backend/test/environment.ts
@@ -111,5 +111,12 @@ export async function startServer(contractOverrides = {}) {
         (await unirep.attesters(unirepSocial.address)).toNumber()
     )
     await new Promise((r) => app.listen(port, r as any))
-    return { ...data, constants, url, attesterId, db: appDB }
+    return {
+        ...data,
+        constants,
+        url,
+        attesterId,
+        db: appDB,
+        txManager: appTxManager,
+    }
 }

--- a/packages/backend/test/username.test.ts
+++ b/packages/backend/test/username.test.ts
@@ -24,7 +24,6 @@ test.before(async (t: any) => {
 test('should set a username', async (t: any) => {
     // sign up and sign in user
     const { iden, commitment } = await signUp(t)
-    await signIn(t, commitment)
 
     // first set a username
     // pre-image by default is 0
@@ -57,47 +56,42 @@ test('should set a username', async (t: any) => {
     t.pass()
 })
 
-test.serial(
-    'should fail to set the username that is already taken',
-    async (t: any) => {
-        // sign up and sign in user
-        const { iden, commitment } = await signUp(t)
-        await signIn(t, commitment)
-
-        // first set a username
-        // pre-image by default is 0
-        await setUsername(t, iden, 0, 'username123')
-
-        await new Promise((r) => setTimeout(r, EPOCH_LENGTH))
-
-        // execute the epoch transition
-        const prevEpoch = await t.context.unirep.currentEpoch()
-        await epochTransition(t)
-        for (;;) {
-            await new Promise((r) => setTimeout(r, 1000))
-            const findEpoch = await t.context.db.findOne('Epoch', {
-                where: { number: Number(prevEpoch) },
-            })
-            if (findEpoch) break
-        }
-
-        // user state transition
-        await userStateTransition(t, iden)
-
-        // try to change the username to the same one
-        try {
-            await setUsername(t, iden, 'username123', 'username123')
-            t.fail()
-        } catch (err: any) {
-            t.true(err.toString().startsWith('Error: /post error'))
-        }
-    }
-)
-
-test.serial('should fail to set with invalid proof', async (t: any) => {
+test('should fail to set the username that is already taken', async (t: any) => {
     // sign up and sign in user
     const { iden, commitment } = await signUp(t)
-    await signIn(t, commitment)
+
+    // first set a username
+    // pre-image by default is 0
+    await setUsername(t, iden, 0, 'username123')
+
+    await new Promise((r) => setTimeout(r, EPOCH_LENGTH))
+
+    // execute the epoch transition
+    const prevEpoch = await t.context.unirep.currentEpoch()
+    await epochTransition(t)
+    for (;;) {
+        await new Promise((r) => setTimeout(r, 1000))
+        const findEpoch = await t.context.db.findOne('Epoch', {
+            where: { number: Number(prevEpoch) },
+        })
+        if (findEpoch) break
+    }
+
+    // user state transition
+    await userStateTransition(t, iden)
+
+    // try to change the username to the same one
+    try {
+        await setUsername(t, iden, 'username123', 'username123')
+        t.fail()
+    } catch (err: any) {
+        t.true(err.toString().startsWith('Error: /post error'))
+    }
+})
+
+test('should fail to set with invalid proof', async (t: any) => {
+    // sign up and sign in user
+    const { iden, commitment } = await signUp(t)
 
     // first set a username
     // pre-image by default is 0

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -316,7 +316,10 @@ export const vote = async (
 }
 
 export const epochTransition = async (t) => {
-    await t.context.unirep.beginEpochTransition().then((t) => t.wait())
+    const { txManager, unirep } = t.context
+    const calldata = unirep.interface.encodeFunctionData('beginEpochTransition')
+    const hash = await txManager.queueTransaction(unirep.address, calldata)
+    await t.context.unirep.provider.waitForTransaction(hash)
 }
 
 export const userStateTransition = async (t, iden) => {

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -316,13 +316,7 @@ export const vote = async (
 }
 
 export const epochTransition = async (t) => {
-    const r = await fetch(`${t.context.url}/api/epochTransition`, {
-        method: 'POST',
-        headers: {
-            authorization: 'NLmKDUnJUpc6VzuPc7Wm',
-        },
-    })
-    t.is(r.status, 204)
+    await t.context.unirep.beginEpochTransition().then((t) => t.wait())
 }
 
 export const userStateTransition = async (t, iden) => {


### PR DESCRIPTION
Fixes the test utils `epochTransition` function. The api route for triggering an epoch transition no longer exists.