### PR TITLE
fix: comment link and link to Semaphore docs

### DIFF
--- a/packages/frontend/src/components/commentBlock.tsx
+++ b/packages/frontend/src/components/commentBlock.tsx
@@ -75,19 +75,19 @@ const CommentBlock = ({ commentId, page }: Props) => {
             <Link
                 className="comment-block-link"
                 to={`/post/${comment.post_id}#${comment.id}`}
-            >
-                <div className="block-content no-padding-horizontal">
-                    <div
-                        style={{
-                            maxHeight: page == Page.Home ? '300px' : undefined,
-                            overflow: 'hidden',
-                        }}
-                        dangerouslySetInnerHTML={{
-                            __html: commentHtml,
-                        }}
-                    />
-                </div>
-            </Link>
+            />
+            <div className="block-content no-padding-horizontal">
+                <div
+                    style={{
+                        maxHeight: page == Page.Home ? '300px' : undefined,
+                        overflow: 'hidden',
+                    }}
+                    dangerouslySetInnerHTML={{
+                        __html: commentHtml,
+                    }}
+                />
+            </div>
+
             <div className="block-buttons no-padding">
                 <BlockButton
                     type={BlockButtonType.Boost}

--- a/packages/frontend/src/layout/sideColumn/privateKeyDetail.tsx
+++ b/packages/frontend/src/layout/sideColumn/privateKeyDetail.tsx
@@ -5,7 +5,7 @@ const PrivateKeyDetail = () => {
             <p>
                 The private key in UniRep social is actually the Semaphore
                 identity. Semaphore enable users online to be freely and fully
-                anonymously. You can learn more about Sempahore{' '}
+                anonymously. You can learn more about Semaphore{' '}
                 <a href="https://semaphore.appliedzkp.org/" target="_blank">
                     here
                 </a>

--- a/packages/frontend/src/layout/sideColumn/privateKeyDetail.tsx
+++ b/packages/frontend/src/layout/sideColumn/privateKeyDetail.tsx
@@ -1,7 +1,7 @@
 const PrivateKeyDetail = () => {
     return (
         <div className="widget private-key-detail">
-            <h4>What’s private key?</h4>
+            <h4>What’s the private key?</h4>
             <p>
                 The private key in UniRep social is actually the Semaphore
                 identity. Semaphore enable users online to be freely and fully

--- a/packages/frontend/src/layout/sideColumn/privateKeyDetail.tsx
+++ b/packages/frontend/src/layout/sideColumn/privateKeyDetail.tsx
@@ -5,7 +5,11 @@ const PrivateKeyDetail = () => {
             <p>
                 The private key in UniRep social is actually the Semaphore
                 identity. Semaphore enable users online to be freely and fully
-                anonymously. You can learn more about Sempahore here.
+                anonymously. You can learn more about Sempahore{' '}
+                <a href="https://semaphore.appliedzkp.org/" target="_blank">
+                    here
+                </a>
+                .
             </p>
 
             <p>


### PR DESCRIPTION
This PR makes it easier to copy text from the comments section by removing the `<Link/>` tag that covered the comment DOM tags and moving it above the comment text.

This PR also adds a link to the Semaphore docs. 
